### PR TITLE
 Fix "not a valid toolchain type" error:

### DIFF
--- a/src/merge-assemblies.bzl
+++ b/src/merge-assemblies.bzl
@@ -23,7 +23,7 @@ def _merged_assembly_impl(ctx):
         executable = ctx.toolchain.merge_tool.path,
         arguments = args,
         inputs = ctx.attr.src_assembly.files,
-        outputs = [ctx.outputs.out]
+        outputs = [ctx.outputs.out],
     )
 
     runfiles = ctx.runfiles(
@@ -47,5 +47,5 @@ merged_assembly = rule(
         "out": attr.output(mandatory = True),
         "keyfile": attr.label(allow_single_file = True),
     },
-    toolchains = ["//tools/ilmerge:ilmerge_toolchain"],
+    toolchains = ["//tools/ilmerge:toolchain_type"],
 )


### PR DESCRIPTION
    The key change here is that rules depend on toolchain types,
    not specific toolchains. This gives Bazel the power to inject
    the appropriate toolchain instances based on platform details.